### PR TITLE
rmasocco/feat/zenoh-json-bridge

### DIFF
--- a/scripts/armv8-base/install_ros2.sh
+++ b/scripts/armv8-base/install_ros2.sh
@@ -78,6 +78,7 @@ if [ "$BASE_UNIT" = "armv8-base" ]; then
     ros-$ROS_DISTRO-launch-testing-ros \
     ros-$ROS_DISTRO-perception \
     ros-$ROS_DISTRO-perception-pcl \
+    ros-$ROS_DISTRO-rclpy-message-converter \
     ros-$ROS_DISTRO-rmw-cyclonedds-cpp \
     ros-$ROS_DISTRO-rmw-fastrtps-cpp \
     ros-$ROS_DISTRO-robot-state-publisher \

--- a/scripts/armv8-base/install_zenoh.sh
+++ b/scripts/armv8-base/install_zenoh.sh
@@ -73,7 +73,7 @@ if [ "$BASE_UNIT" = "armv8-base" ]; then
   ldconfig
 
   # Install Zenoh Python API
-  pip install eclipse-zenoh
+  pip install eclipse-zenoh=="${ZENOH_VERSION}"
 
   # Build and install Zenoh C API, cleanup
   git clone --depth 1 --single-branch \

--- a/scripts/armv8-dev/install_ros2.sh
+++ b/scripts/armv8-dev/install_ros2.sh
@@ -80,6 +80,7 @@ if [ "$BASE_UNIT" = "armv8-dev" ]; then
     ros-$ROS_DISTRO-perception \
     ros-$ROS_DISTRO-perception-pcl \
     ros-$ROS_DISTRO-plotjuggler-ros \
+    ros-$ROS_DISTRO-rclpy-message-converter \
     ros-$ROS_DISTRO-rmw-cyclonedds-cpp \
     ros-$ROS_DISTRO-rmw-fastrtps-cpp \
     ros-$ROS_DISTRO-robot-state-publisher \

--- a/scripts/armv8-dev/install_zenoh.sh
+++ b/scripts/armv8-dev/install_zenoh.sh
@@ -73,7 +73,7 @@ if [ "$BASE_UNIT" = "armv8-dev" ]; then
   ldconfig
 
   # Install Zenoh Python API
-  pip install eclipse-zenoh
+  pip install eclipse-zenoh=="${ZENOH_VERSION}"
 
   # Build and install Zenoh C API, cleanup
   git clone --depth 1 --single-branch \

--- a/scripts/jetson5/install_zenoh.sh
+++ b/scripts/jetson5/install_zenoh.sh
@@ -73,7 +73,7 @@ if [ "$BASE_UNIT" = "jetson5" ]; then
   ldconfig
 
   # Install Zenoh Python API
-  pip install eclipse-zenoh
+  pip install eclipse-zenoh=="${ZENOH_VERSION}"
 
   # Build and install Zenoh C API, cleanup
   git clone --depth 1 --single-branch \

--- a/scripts/jetson5/install_zenoh.sh
+++ b/scripts/jetson5/install_zenoh.sh
@@ -73,7 +73,12 @@ if [ "$BASE_UNIT" = "jetson5" ]; then
   ldconfig
 
   # Install Zenoh Python API
-  pip install eclipse-zenoh=="${ZENOH_VERSION}"
+  # NOTE: We have to install version 1.5.1 here, since it is the last one shipping
+  #       with a cp38-compatible wheel.
+  #       It is never going to be updated, support has been dropped.
+  #       Wire protocol is going to stay consistent among 1.x versions, but
+  #       newer fancy API will not make it here.
+  pip install eclipse-zenoh==1.5.1
 
   # Build and install Zenoh C API, cleanup
   git clone --depth 1 --single-branch \

--- a/scripts/jetson6/install_zenoh.sh
+++ b/scripts/jetson6/install_zenoh.sh
@@ -73,7 +73,7 @@ if [ "$BASE_UNIT" = "jetson6" ]; then
   ldconfig
 
   # Install Zenoh Python API
-  pip install eclipse-zenoh
+  pip install eclipse-zenoh=="${ZENOH_VERSION}"
 
   # Build and install Zenoh C API, cleanup
   git clone --depth 1 --single-branch \

--- a/scripts/ros2/dua-utils_repos_base.yaml
+++ b/scripts/ros2/dua-utils_repos_base.yaml
@@ -115,8 +115,12 @@ repositories:
   dotX-Automation/targets_converter:
     type: git
     url: https://github.com/dotX-Automation/targets_converter.git
-    version: v1.1.2
+    version: v1.1.4
   dotX-Automation/transitions_ros:
     type: git
     url: https://github.com/dotX-Automation/transitions_ros.git
     version: v1.2.0
+  dotX-Automation/zenoh_json_bridge:
+    type: git
+    url: https://github.com/dotX-Automation/zenoh_json_bridge.git
+    version: v1.0.0

--- a/scripts/ros2/dua-utils_repos_dev.yaml
+++ b/scripts/ros2/dua-utils_repos_dev.yaml
@@ -123,8 +123,12 @@ repositories:
   dotX-Automation/targets_converter:
     type: git
     url: https://github.com/dotX-Automation/targets_converter.git
-    version: v1.1.2
+    version: v1.1.4
   dotX-Automation/transitions_ros:
     type: git
     url: https://github.com/dotX-Automation/transitions_ros.git
     version: v1.2.0
+  dotX-Automation/zenoh_json_bridge:
+    type: git
+    url: https://github.com/dotX-Automation/zenoh_json_bridge.git
+    version: v1.0.0

--- a/scripts/ros2/ros2_jazzy_repos_base.yml
+++ b/scripts/ros2/ros2_jazzy_repos_base.yml
@@ -398,6 +398,10 @@ repositories:
     version: release/jazzy/xacro
 
   # ADDITIONAL LIBRARIES AND DEPENDENCIES #
+  DFKI-NI/rospy_message_converter:
+    type: git
+    url: https://github.com/DFKI-NI/rospy_message_converter.git
+    version: jazzy
   fmrico/yaets:
     type: git
     url: https://github.com/fmrico/yaets.git

--- a/scripts/x86-base/install_ros2.sh
+++ b/scripts/x86-base/install_ros2.sh
@@ -78,6 +78,7 @@ if [ "$BASE_UNIT" = "x86-base" ]; then
     ros-$ROS_DISTRO-launch-testing-ros \
     ros-$ROS_DISTRO-perception \
     ros-$ROS_DISTRO-perception-pcl \
+    ros-$ROS_DISTRO-rclpy-message-converter \
     ros-$ROS_DISTRO-rmw-cyclonedds-cpp \
     ros-$ROS_DISTRO-rmw-fastrtps-cpp \
     ros-$ROS_DISTRO-robot-state-publisher \

--- a/scripts/x86-base/install_zenoh.sh
+++ b/scripts/x86-base/install_zenoh.sh
@@ -73,7 +73,7 @@ if [ "$BASE_UNIT" = "x86-base" ]; then
   ldconfig
 
   # Install Zenoh Python API
-  pip install eclipse-zenoh
+  pip install eclipse-zenoh=="${ZENOH_VERSION}"
 
   # Build and install Zenoh C API, cleanup
   git clone --depth 1 --single-branch \

--- a/scripts/x86-cudev/install_ros2.sh
+++ b/scripts/x86-cudev/install_ros2.sh
@@ -80,6 +80,7 @@ if [ "$BASE_UNIT" = "x86-cudev" ]; then
     ros-$ROS_DISTRO-perception \
     ros-$ROS_DISTRO-perception-pcl \
     ros-$ROS_DISTRO-plotjuggler-ros \
+    ros-$ROS_DISTRO-rclpy-message-converter \
     ros-$ROS_DISTRO-rmw-cyclonedds-cpp \
     ros-$ROS_DISTRO-rmw-fastrtps-cpp \
     ros-$ROS_DISTRO-robot-state-publisher \

--- a/scripts/x86-cudev/install_zenoh.sh
+++ b/scripts/x86-cudev/install_zenoh.sh
@@ -73,7 +73,7 @@ if [ "$BASE_UNIT" = "x86-cudev" ]; then
   ldconfig
 
   # Install Zenoh Python API
-  pip install eclipse-zenoh
+  pip install eclipse-zenoh=="${ZENOH_VERSION}"
 
   # Build and install Zenoh C API, cleanup
   git clone --depth 1 --single-branch \

--- a/scripts/x86-dev/install_ros2.sh
+++ b/scripts/x86-dev/install_ros2.sh
@@ -80,6 +80,7 @@ if [ "$BASE_UNIT" = "x86-dev" ]; then
     ros-$ROS_DISTRO-perception \
     ros-$ROS_DISTRO-perception-pcl \
     ros-$ROS_DISTRO-plotjuggler-ros \
+    ros-$ROS_DISTRO-rclpy-message-converter \
     ros-$ROS_DISTRO-rmw-cyclonedds-cpp \
     ros-$ROS_DISTRO-rmw-fastrtps-cpp \
     ros-$ROS_DISTRO-robot-state-publisher \

--- a/scripts/x86-dev/install_zenoh.sh
+++ b/scripts/x86-dev/install_zenoh.sh
@@ -73,7 +73,7 @@ if [ "$BASE_UNIT" = "x86-dev" ]; then
   ldconfig
 
   # Install Zenoh Python API
-  pip install eclipse-zenoh
+  pip install eclipse-zenoh=="${ZENOH_VERSION}"
 
   # Build and install Zenoh C API, cleanup
   git clone --depth 1 --single-branch \


### PR DESCRIPTION
This PR adds support for the upcoming `zenoh_json_bridge` Python package among the utils, adding core dependencies and pinning the version of the installed Zenoh Python API.